### PR TITLE
Fix: importing golang.org/x/net/websocket

### DIFF
--- a/hopwatch.go
+++ b/hopwatch.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"sync"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 // command is used to transport message to and from the debugger.


### PR DESCRIPTION
Hi,

code.google.com has warned us earlier to be switched off. Now it's high time to replace the imported lib to working one.

Greetings,
Marcin
